### PR TITLE
Granted the scheduler service account run.invoker role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,13 @@ resource "google_service_account" "default" {
   display_name = "${var.name}-scheduler-sa"
 }
 
+resource "google_project_iam_member" "run_invoker" {
+  project = var.project_id
+
+  role   = "roles/run.invoker"
+  member = "serviceAccount:${google_service_account.default.email}"
+}
+
 data "google_cloud_run_service" "default" {
   depends_on = [
     module.function2


### PR DESCRIPTION
## What
* Granted the scheduler service account permissions to invoke the cloud run job.

## Why
* Scheduler currently doesn't have the required permissions to invoke Cloud Run.

## References
* Use `closes #123`, if this PR closes a GitHub issue `#123`
